### PR TITLE
Include user mail in the displayname

### DIFF
--- a/src/DataCatalog.Api/Services/AD/AzureGroupService.cs
+++ b/src/DataCatalog.Api/Services/AD/AzureGroupService.cs
@@ -112,7 +112,7 @@ namespace DataCatalog.Api.Services.AD
             await Task.WhenAll(groupsTask, usersTask, servicePrincipalsTask);
 
             var result = groupsTask.Result.Where(x => !x.GroupTypes.Contains("Unified")).Select(x => new AdSearchResult {Id = x.Id, DisplayName = x.DisplayName, Type = AdSearchResultType.Group})
-                .Union(usersTask.Result.Select(x => new AdSearchResult { Id = x.Id, DisplayName = x.DisplayName, Type = AdSearchResultType.User }))
+                .Union(usersTask.Result.Select(x => new AdSearchResult { Id = x.Id, DisplayName = $"{x.DisplayName} ({x.Mail})", Type = AdSearchResultType.User }))
                 .Union(servicePrincipalsTask.Result.Select(x => new AdSearchResult { Id = x.Id, DisplayName = x.DisplayName, Type = AdSearchResultType.ServicePrincipal }));
 
             return result;
@@ -124,7 +124,7 @@ namespace DataCatalog.Api.Services.AD
                 return new AccessMember {Id = groupMember.Id, Name = groupMember.DisplayName, Type = AccessMemberType.Group};
             
             if (memberDirectoryObject is Microsoft.Graph.User userMember)
-                return new AccessMember { Id = userMember.Id, Name = userMember.DisplayName, Type = AccessMemberType.User };
+                return new AccessMember { Id = userMember.Id, Name = $"{userMember.DisplayName} ({userMember.Mail})", Type = AccessMemberType.User };
             
             if (memberDirectoryObject is ServicePrincipal servicePrincipalMember)
                 return new AccessMember { Id = servicePrincipalMember.Id, Name = servicePrincipalMember.DisplayName, Type = AccessMemberType.ServicePrincipal };

--- a/src/DataCatalog.Api/Services/AD/AzureGroupService.cs
+++ b/src/DataCatalog.Api/Services/AD/AzureGroupService.cs
@@ -102,7 +102,7 @@ namespace DataCatalog.Api.Services.AD
 
         public async Task<IEnumerable<AdSearchResult>> SearchAsync(string searchString)
         {
-            var searchQueryOption = new QueryOption("$search", $"\"displayName:{searchString}\"");
+            var searchQueryOption = new QueryOption("$search", $"\"{searchString}\"");
             var consistencyLevelHeader = new HeaderOption("ConsistencyLevel", "eventual");
             
             var groupsTask = _graphServiceClient.Groups.Request(new List<Option> { searchQueryOption, consistencyLevelHeader }).GetAsync();

--- a/tests/unit/DataCatalog.Api.UnitTests/Services/AD/AzureActiveDirectoryGroupService_Should.cs
+++ b/tests/unit/DataCatalog.Api.UnitTests/Services/AD/AzureActiveDirectoryGroupService_Should.cs
@@ -51,7 +51,7 @@ namespace DataCatalog.Api.UnitTests.Services.AD
             members.Any(x =>
                 Equals(x.Type, AccessMemberType.User) &&
                 Equals(x.Id, userMember.Id)
-                && Equals(x.Name, userMember.DisplayName)).ShouldBe(true);
+                && Equals(x.Name, $"{userMember.DisplayName} ({userMember.Mail})")).ShouldBe(true);
 
             members.Any(x =>
                 Equals(x.Type, AccessMemberType.ServicePrincipal) &&
@@ -115,7 +115,7 @@ namespace DataCatalog.Api.UnitTests.Services.AD
 
             // Assert
             member.Id.ShouldBe(user.Id);
-            member.Name.ShouldBe(user.DisplayName);
+            member.Name.ShouldBe($"{user.DisplayName} ({user.Mail})");
             member.Type.ShouldBe(AccessMemberType.User);
         }
 
@@ -426,13 +426,13 @@ namespace DataCatalog.Api.UnitTests.Services.AD
 
             // Assert
             results.Any(x =>
-                Equals(x.DisplayName, user1.DisplayName) && Equals(x.Id, user1.Id) &&
+                Equals(x.DisplayName, $"{user1.DisplayName} ({user1.Mail})") && Equals(x.Id, user1.Id) &&
                 Equals(x.Type, AdSearchResultType.User)).ShouldBeTrue();
             results.Any(x =>
-                Equals(x.DisplayName, user2.DisplayName) && Equals(x.Id, user2.Id) &&
+                Equals(x.DisplayName, $"{user2.DisplayName} ({user2.Mail})") && Equals(x.Id, user2.Id) &&
                 Equals(x.Type, AdSearchResultType.User)).ShouldBeTrue();
             results.Any(x =>
-                Equals(x.DisplayName, user3.DisplayName) && Equals(x.Id, user3.Id) &&
+                Equals(x.DisplayName, $"{user3.DisplayName} ({user3.Mail})") && Equals(x.Id, user3.Id) &&
                 Equals(x.Type, AdSearchResultType.User)).ShouldBeTrue();
         }
     }


### PR DESCRIPTION
Do we think this might be an issue for groups as well? Can groups be called the same, and would thus need the email added as well? 
Also, maybe we only want the email added if there are multiple of the same displayname? But likely that would just confuse users.