### PR TITLE
Fixed updates of source datasets

### DIFF
--- a/src/DataCatalog.Api/Data/AutoMapperProfile.cs
+++ b/src/DataCatalog.Api/Data/AutoMapperProfile.cs
@@ -183,7 +183,10 @@ namespace DataCatalog.Api.Data
                     c.SinkDatasets.Select(d => new TransformationDataset { DatasetId = d.Id, TransformationDirection = TransformationDirection.Sink, TransformationId = c.Id })
                     .Concat(c.SourceDatasets.Select(d => new TransformationDataset { DatasetId = d.Id, TransformationDirection = TransformationDirection.Source, TransformationId = c.Id }))));
 
-            CreateMap<SourceTransformationUpsertRequest, Transformation>();
+            CreateMap<SourceTransformationUpsertRequest, Transformation>()
+                .ForMember(a => a.TransformationDatasets, b => b.MapFrom(c =>
+                    c.SourceDatasets.Select(d => new TransformationDataset { DatasetId = d.Id, TransformationDirection = TransformationDirection.Source, TransformationId = c.Id.HasValue ? c.Id.Value : Guid.Empty })));
+
             CreateMap<SourceTransformationUpsertRequest, Domain.Transformation>();
             CreateMap<Transformation, Domain.Transformation>();
             CreateMap<Domain.Transformation, Transformation>();

--- a/src/DataCatalog.Api/Repositories/ITransformationDatasetRepository.cs
+++ b/src/DataCatalog.Api/Repositories/ITransformationDatasetRepository.cs
@@ -9,12 +9,11 @@ namespace DataCatalog.Api.Repositories
     public interface ITransformationDatasetRepository
     {
         Task<IEnumerable<TransformationDataset>> ListAsync();
-        Task<TransformationDataset> FindByDatasetIdAndDirectionAsync(Guid datasetId, TransformationDirection direction);
+        Task<TransformationDataset> FindByDatasetIdAndDirectionAsync(Guid datasetId, TransformationDirection direction, Guid transformationId);
         Task<IEnumerable<TransformationDataset>> FindAllTransformationDatasetsForDatasetIdAndDirectionAsync(Guid datasetId, TransformationDirection direction);
         Task<IEnumerable<TransformationDataset>> FindAllByTransformationIdAndDirectionAsync(Guid transformationId, TransformationDirection direction);
         Task AddAsync(TransformationDataset transformationDataset);
         void Update(TransformationDataset transformationDataset);
         Task RemoveAsync(TransformationDataset transformationDataset);
-        void Remove(List<TransformationDataset> transformationDatasets);
     }
 }

--- a/src/DataCatalog.Api/Repositories/TransformationDatasetRepository.cs
+++ b/src/DataCatalog.Api/Repositories/TransformationDatasetRepository.cs
@@ -20,13 +20,17 @@ namespace DataCatalog.Api.Repositories
             return await _context.TransformationDatasets.ToListAsync();
         }
 
-        public async Task<TransformationDataset> FindByDatasetIdAndDirectionAsync(Guid datasetId, TransformationDirection direction)
+        public async Task<TransformationDataset> FindByDatasetIdAndDirectionAsync(Guid datasetId, TransformationDirection direction, Guid transformationId)
         {
             return await _context.TransformationDatasets
                 .Include(transformationDataset => transformationDataset.Transformation).ThenInclude(a => a.TransformationDatasets)
                 .Include(transformationDataset => transformationDataset.Dataset)
                 .Where(transformationDataset => !transformationDataset.Dataset.IsDeleted)
-                .Where(transformationDataset => transformationDataset.DatasetId == datasetId && transformationDataset.TransformationDirection == direction).FirstOrDefaultAsync();
+                .Where(transformationDataset => 
+                    transformationDataset.DatasetId == datasetId 
+                    && transformationDataset.TransformationDirection == direction
+                    && transformationDataset.TransformationId == transformationId)
+                .FirstOrDefaultAsync();
         }
 
         public async Task<IEnumerable<TransformationDataset>> FindAllTransformationDatasetsForDatasetIdAndDirectionAsync(Guid datasetId, TransformationDirection direction)
@@ -64,11 +68,6 @@ namespace DataCatalog.Api.Repositories
                 t.TransformationDirection == transformationDataset.TransformationDirection);
             if (entityToRemove != null)
                 _context.TransformationDatasets.Remove(entityToRemove);
-        }
-
-        public void Remove(List<TransformationDataset> transformationDatasets)
-        {
-            Task.WaitAll(transformationDatasets.Select(RemoveAsync).ToArray());
         }
     }
 }

--- a/tests/integration/DataCatalog.Api.IntegrationTests/Repositories/TransformationDatasetRepositoryTests.cs
+++ b/tests/integration/DataCatalog.Api.IntegrationTests/Repositories/TransformationDatasetRepositoryTests.cs
@@ -97,7 +97,7 @@ namespace DataCatalog.Api.IntegrationTests.Repositories
             var invalidDatasetId = Guid.NewGuid();
 
             // ACT
-            var transformationDataset = await transformationDatasetRepository.FindByDatasetIdAndDirectionAsync(invalidDatasetId, direction);
+            var transformationDataset = await transformationDatasetRepository.FindByDatasetIdAndDirectionAsync(invalidDatasetId, direction, _transformations[0].Id);
 
             // ASSERT
             transformationDataset.Should().BeNull();
@@ -110,7 +110,7 @@ namespace DataCatalog.Api.IntegrationTests.Repositories
             var transformationDatasetRepository = new TransformationDatasetRepository(_context);
 
             // ACT
-            var transformationDataset = await transformationDatasetRepository.FindByDatasetIdAndDirectionAsync(_datasets[0].Id, TransformationDirection.Sink);
+            var transformationDataset = await transformationDatasetRepository.FindByDatasetIdAndDirectionAsync(_datasets[0].Id, TransformationDirection.Sink, _transformations[0].Id);
 
             // ASSERT
             transformationDataset.Should().BeNull();
@@ -123,7 +123,7 @@ namespace DataCatalog.Api.IntegrationTests.Repositories
             var transformationDatasetRepository = new TransformationDatasetRepository(_context);
 
             // ACT
-            var transformationDataset = await transformationDatasetRepository.FindByDatasetIdAndDirectionAsync(_datasets[0].Id, TransformationDirection.Source);
+            var transformationDataset = await transformationDatasetRepository.FindByDatasetIdAndDirectionAsync(_datasets[0].Id, TransformationDirection.Source, _transformations[0].Id);
 
             // ASSERT
             transformationDataset.Should().NotBeNull();
@@ -287,29 +287,6 @@ namespace DataCatalog.Api.IntegrationTests.Repositories
                 t.DatasetId == transformationDatasetToRemove.DatasetId &&
                 t.TransformationId == transformationDatasetToRemove.TransformationId && t.TransformationDirection ==
                 transformationDatasetToRemove.TransformationDirection).Should().BeNull();
-        }
-
-        [Fact]
-        public async Task Remove_ShouldBeRemoved()
-        {
-            // ARRANGE
-            var transformationDatasetRepository = new TransformationDatasetRepository(_context);
-            var transformationDatasetsToRemove = _transformationDatasets.Take(2).ToList();
-
-            // ACT
-            transformationDatasetRepository.Remove(transformationDatasetsToRemove);
-            await _context.SaveChangesAsync();
-
-            // ASSERT
-            var allTransformationDatasets = await transformationDatasetRepository.ListAsync();
-            var transformationDatasetArray = allTransformationDatasets as TransformationDataset[] ?? allTransformationDatasets.ToArray();
-            transformationDatasetArray.Should().NotBeNull();
-
-            transformationDatasetsToRemove.ForEach(td =>
-                transformationDatasetArray.SingleOrDefault(t =>
-                    t.DatasetId == td.DatasetId &&
-                    t.TransformationId == td.TransformationId && t.TransformationDirection ==
-                    td.TransformationDirection).Should().BeNull());
         }
     }
 }


### PR DESCRIPTION
Hele feature'en omkring transformations er lavet på en super forvirrende måde og synes stadig der er nogle ting, hvor det ikke er helt klart hvordan det bør virke. 

Var først igang med en større refaktorering, men så fandt jeg ud af, at det jeg prøvede at gøre i stedet heller ikke gav mening, så jeg endte med at reverte det hele og nøjes med udelukkende at fikse det nuværende så delete fungerer. 

Der er stadig nogle ting der fungerer lidt funky, fx man først laver en transformation og derefter tilføjer en source mere, så laver den en ny transformation med de gamle plus den nye og så bliver de gamle vist to gange i oversigten. 

Generelt tror jeg hele transformation feature'en kunne trænge til en snak omkring hvad det skal kunne og hvordan det skal bruges, men det lyder som om det er på vej ift at forbedre data lineage.