### PR TITLE
Add metadataProvider role to Current

### DIFF
--- a/src/DataCatalog.Api/Extensions/CurrentUserInitializationMiddleware.cs
+++ b/src/DataCatalog.Api/Extensions/CurrentUserInitializationMiddleware.cs
@@ -69,6 +69,8 @@ namespace DataCatalog.Api.Extensions
                 _current.Roles.Add(Role.DataSteward);
             if (executingUser.IsInRole(Role.User.ToString()))
                 _current.Roles.Add(Role.User);
+            if (executingUser.IsInRole(Role.MetadataProvider.ToString()))
+                _current.Roles.Add(Role.MetadataProvider);
         }
     }
 }


### PR DESCRIPTION
Forgot to add the role to Current - silly that we use this custom stuff instead of using asp.net core's internal stuff, but oh well..